### PR TITLE
teach the programmer about S-records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,11 +9,9 @@ bak/*
 *-backups/
 _autosave*
 #auto_saved_files#
+hw/simm/programmer/firmware/build/*
 sw/rom/mon/mon.map
 sw/rom/mon/mon.bin
 sw/rom/boot.bin
 sw/rom/os.bin
 sw/rom/tos.bin
-fw/a1/bak/*
-
-


### PR DESCRIPTION
S-records are less compact than binary records, but have per-line checksums that should help catch serial transfer issues.

Multiple S-record files can be concatenated and sent as a single upload, e.g. `mon` and EmuTOS can be compiled to S-records (or to ELF for debug purposes) and then uploaded without having to generate an intermediate binary image.
