### PR TITLE
Teach mon to handle S-record uploads to RAM

### DIFF
--- a/sw/rom/mon/lib.c
+++ b/sw/rom/mon/lib.c
@@ -331,7 +331,7 @@ hexdump(const uint8_t *addr, uint32_t address, size_t length, char width)
                 }
             } else {
                 const uint8_t *p = (addr + index + col);
-                uint32_t val = WSELECT(width, *(const uint32_t *)p, *(const uint16_t *)p, *(const uint8_t *)p);
+                uint32_t val = WSELECT(width, *(const volatile uint32_t *)p, *(const volatile uint16_t *)p, *(const volatile uint8_t *)p);
                 putx(val, incr);
             }
         }

--- a/sw/rom/test/Makefile
+++ b/sw/rom/test/Makefile
@@ -1,0 +1,66 @@
+#
+# Build an uploadable test app.
+#
+
+TOOLCHAIN	 = m68k-atari-mintelf
+CC		 = $(TOOLCHAIN)-gcc
+OBJCOPY		 = $(TOOLCHAIN)-objcopy
+LIBGCC		:= $(shell $(CC) --print-file-name libgcc.a)
+CC_INCLUDES	 = $(dir $(LIBGCC))include
+
+TEST_ELF	 = test.elf
+TEST_SREC	 = test.s19
+
+SFILES		:= $(wildcard *.S)
+CFILES		:= $(wildcard *.c) \
+		   ../mon/lib.c \
+		   ../mon/hw/uart.c
+
+OFILES		 = $(SFILES:%.S=build/%.o) $(CFILES:%.c=build/%.o)
+DEPS   		 = $(MAKEFILE_LIST) test.ld
+
+SFLAGS		 = $(DEFS) -m68060 -D__ASM__
+
+CFLAGS		 = $(DEFS) \
+		   -m68060 \
+		   -Os \
+		   -std=c17 \
+		   -ffreestanding \
+		   -fomit-frame-pointer \
+		   -fno-common \
+		   -fdata-sections \
+		   -ffunction-sections \
+		   -Wall \
+		   -MMD \
+		   -nostdinc \
+		   -I$(CC_INCLUDES) \
+		   -I../mon
+
+LDFLAGS 	 = -nolibc \
+		   -nostartfiles \
+		   -ffreestanding \
+		   -Wl,-Map,$@.map \
+		   -T test.ld
+
+.PHONY: all
+all: $(TEST_SREC)
+
+$(TEST_ELF): $(OFILES) $(DEPS)
+	$(CC) $(LDFLAGS) $(OFILES) -o $@
+
+$(TEST_SREC): $(TEST_ELF)
+	$(OBJCOPY) -O srec --srec-forceS3 $(TEST_ELF) $@
+
+build/%.o : %.S $(DEPS)
+	@mkdir -p $(@D)
+	$(CC) $(SFLAGS) -c $< -o $@
+
+build/%.o : %.c $(DEPS)
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f -r build/*
+	rm -f *.elf *.map *.s19
+
+-include build/*.d

--- a/sw/rom/test/main.c
+++ b/sw/rom/test/main.c
@@ -1,0 +1,18 @@
+/*
+ * Raven test program.
+ */
+
+#include <lib.h>
+
+extern uint8_t __bss_start, __bss_end;
+
+void main(void)
+{
+    puts("test");
+}
+
+void _main(void)
+{
+	memset(&__bss_start, 0, &__bss_end - &__bss_start);
+    main();
+}

--- a/sw/rom/test/start.S
+++ b/sw/rom/test/start.S
@@ -1,0 +1,18 @@
+/*
+ * startup code for test program
+ */
+
+    .globl _main
+    .globl _exit
+    .section .note.GNU-stack,"",%progbits
+
+    .text
+    .align 2
+    .globl start
+    .globl __stack_top
+    .type start,@function
+start:
+    move.w  #0x2700,%sr
+    lea     __stack_top,%sp
+    jbsr    _main
+    jbra    .

--- a/sw/rom/test/test.ld
+++ b/sw/rom/test/test.ld
@@ -1,0 +1,41 @@
+/*
+ * Raven monitor upload.
+ */
+
+OUTPUT_ARCH(m68k)
+OUTPUT_FORMAT(elf32-m68k)
+ENTRY(start)
+
+MEMORY
+{
+	RAM(RW) : ORIGIN = 0x00000400, LENGTH = 0x001ffc00
+}
+
+SECTIONS
+{
+	.text :
+	{
+		*(.text* .rodata*)			/* text and text-like things */
+	} >RAM
+
+	.data :
+	{
+		__data_start = .;
+		*(.data*)					/* non-constant initialised data */
+		. = ALIGN(4);
+		__data_end = .;
+	} >RAM
+
+	.bss :
+	{
+		__bss_start = .;
+		*(.bss*);					/* non-constant, non-initialised data */
+		. = ALIGN(4);
+		__bss_end = .;
+
+		__stack_base = .;			/* stack */
+		. = ORIGIN(RAM) + LENGTH(RAM) - 4;
+		. = ALIGN(4);
+		__stack_top = .;
+	} > RAM
+}


### PR DESCRIPTION
More reliable / flexible than the raw binary upload.

Simple test program included as a skeleton. This makes iterating on hardware tests much easier, as it's no longer necessary to swap the SIMM between Raven and the programmer.
